### PR TITLE
Espresso tests for settings fragment

### DIFF
--- a/.github/workflows/espresso_tests.yml
+++ b/.github/workflows/espresso_tests.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           api-level: 29
           profile: 'Nexus 6'
-          script: ./gradlew connectedCheck --info --stacktrace
+          script: ./gradlew connectedCompleteDebugAndroidTest --info --stacktrace

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: "true"
     }
 
     flavorDimensions "type"
@@ -108,6 +109,7 @@ android {
 
     testOptions {
         animationsDisabled = true
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 }
 
@@ -145,6 +147,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test:runner:$androidxTestVersion"
     androidTestImplementation "androidx.test:rules:$androidxTestVersion"
+    androidTestUtil "androidx.test:orchestrator:$androidxTestVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
@@ -1,7 +1,6 @@
 package xyz.lbres.trickcalculator.helpers.viewassertion
 
 import android.view.View
-import androidx.core.view.isVisible
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 import androidx.test.espresso.util.HumanReadables
@@ -17,7 +16,7 @@ class NotPresentedViewAssertion : ViewAssertion {
      * Assert that a view is not in the view hierarchy or is not visible
      */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
-        if (view != null && view.isVisible) {
+        if (view != null && view.isShown) {
             val viewText = HumanReadables.describe(view)
             throw AssertionError("View is present in hierarchy and visible: $viewText")
         }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
@@ -18,7 +18,7 @@ class NotPresentedViewAssertion : ViewAssertion {
      */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (view != null && view.isVisible) {
-            assertThat("View is present in hierarchy and visible", true)
+            throw AssertionError("View is present in hierarchy and visible")
         }
     }
 }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
@@ -14,6 +14,8 @@ import androidx.test.espresso.util.HumanReadables
 class NotPresentedViewAssertion : ViewAssertion {
     /**
      * Assert that a view is not in the view hierarchy or is not visible
+     *
+     * @param view [View]?: view to check
      */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (view != null && view.isShown) {

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/viewassertion/NotPresentedViewAssertion.kt
@@ -4,7 +4,7 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
-import org.hamcrest.MatcherAssert.assertThat
+import androidx.test.espresso.util.HumanReadables
 
 /**
  * [ViewAssertion] to assert that view is not presented on screen, due to not existing or not being visible.
@@ -18,7 +18,8 @@ class NotPresentedViewAssertion : ViewAssertion {
      */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (view != null && view.isVisible) {
-            throw AssertionError("View is present in hierarchy and visible")
+            val viewText = HumanReadables.describe(view)
+            throw AssertionError("View is present in hierarchy and visible: $viewText")
         }
     }
 }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/wrapperFunctions.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/helpers/wrapperFunctions.kt
@@ -78,4 +78,4 @@ fun withNestedViewHolder(
 /**
  * Wrapper function for creating a [NotPresentedViewAssertion]
  */
-fun notPresented() = NotPresentedViewAssertion()
+fun isNotPresented() = NotPresentedViewAssertion()

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/AttributionsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/AttributionsFragmentTest.kt
@@ -28,6 +28,8 @@ import xyz.lbres.trickcalculator.helpers.assertLinkOpened
 import xyz.lbres.trickcalculator.helpers.clickLinkInText
 import xyz.lbres.trickcalculator.helpers.forceClick
 
+// TODO verify that values are not saved when leaving/returning
+
 @RunWith(AndroidJUnit4::class)
 class AttributionsFragmentTest {
     private val intent = Intent(ApplicationProvider.getApplicationContext(), MainActivity::class.java)

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/recyclerViewTests.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/recyclerViewTests.kt
@@ -18,7 +18,7 @@ import xyz.lbres.trickcalculator.helpers.actionOnItemViewAtPosition
 import xyz.lbres.trickcalculator.helpers.actionOnNestedItemViewAtPosition
 import xyz.lbres.trickcalculator.helpers.assertLinkOpened
 import xyz.lbres.trickcalculator.helpers.clickLinkInText
-import xyz.lbres.trickcalculator.helpers.notPresented
+import xyz.lbres.trickcalculator.helpers.isNotPresented
 import xyz.lbres.trickcalculator.helpers.withNestedViewHolder
 import xyz.lbres.trickcalculator.helpers.withViewHolder
 import xyz.lbres.trickcalculator.ui.attributions.authorattribution.AuthorAttributionViewHolder
@@ -152,7 +152,7 @@ fun testAttributionLinks() {
 private fun checkImagesNotPresented(positions: IntList) {
     for (position in positions) {
         for (url in imageUrls[position]) {
-            onView(withText(url)).check(notPresented())
+            onView(withText(url)).check(isNotPresented())
         }
     }
 }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/recyclerViewTests.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/attributions/recyclerViewTests.kt
@@ -151,6 +151,7 @@ fun testAttributionLinks() {
  */
 private fun checkImagesNotPresented(positions: IntList) {
     for (position in positions) {
+        onView(withId(recyclerId)).perform(RecyclerViewActions.scrollToPosition<AuthorAttributionViewHolder>(0))
         for (url in imageUrls[position]) {
             onView(withText(url)).check(isNotPresented())
         }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/main/MainFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/main/MainFragmentTest.kt
@@ -19,6 +19,8 @@ import xyz.lbres.trickcalculator.MainActivity
 import xyz.lbres.trickcalculator.R
 import xyz.lbres.trickcalculator.helpers.checkVisibleWithText
 
+// TODO verify that values are saved when leaving/returning
+
 @RunWith(AndroidJUnit4::class)
 class MainFragmentTest {
     private lateinit var mainText: ViewInteraction

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
@@ -1,5 +1,6 @@
 package xyz.lbres.trickcalculator.ui.settings
 
+import androidx.annotation.IdRes
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
@@ -12,13 +13,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import xyz.lbres.kotlinutils.general.ternaryIf
 import xyz.lbres.trickcalculator.MainActivity
 import xyz.lbres.trickcalculator.R
 import xyz.lbres.trickcalculator.helpers.forceClick
+import xyz.lbres.trickcalculator.helpers.isNotPresented
 
 @RunWith(AndroidJUnit4::class)
 class SettingsFragmentTest {
@@ -26,53 +28,129 @@ class SettingsFragmentTest {
     @JvmField
     val rule = ActivityScenarioRule(MainActivity::class.java)
 
-    @Before
-    fun setupTest() {
-        // open fragment
-        val infoButton = onView(withId(R.id.infoButton))
-        infoButton.check(matches(isDisplayed()))
-        infoButton.perform(click())
-        onView(withId(R.id.title)).perform(click())
-    }
-
     @Test
     fun loadActionBarWithTitle() {
+        openFragment()
         val expectedTitle = "Settings"
         onView(withId(R.id.title)).check(matches(withText(expectedTitle)))
     }
 
     @Test
     fun loadFullUi() {
-        onView(withId(R.id.applyParensSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
-        onView(withId(R.id.applyDecimalsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
-        onView(withId(R.id.shuffleComputationSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
-        onView(withId(R.id.shuffleNumbersSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
-        onView(withId(R.id.shuffleOperatorsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
-
-        onView(withId(R.id.clearOnErrorSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+        openFragment()
+        checkInitialSettings()
         onView(withId(R.id.settingsButtonSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
-
-        onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
-        onView(withId(R.id.historyButton1)).check(matches(isChecked()))
-
         onView(withId(R.id.resetSettingsButton)).check(matches(isDisplayed()))
         onView(withId(R.id.randomizeSettingsButton)).check(matches(isDisplayed()))
     }
 
     @Test
     fun interactWithUi() {
-        // TODO
+        openFragment()
+        // switches
+        testSwitch(R.id.applyParensSwitch, true)
+        testSwitch(R.id.applyDecimalsSwitch, true)
+        testSwitch(R.id.shuffleComputationSwitch, false)
+        testSwitch(R.id.shuffleNumbersSwitch, false)
+        testSwitch(R.id.shuffleOperatorsSwitch, true)
+
+        testSwitch(R.id.clearOnErrorSwitch, false)
+        testSwitch(R.id.settingsButtonSwitch, false)
+
+        // history group
+        val button0 = onView(withId(R.id.historyButton0))
+        val button1 = onView(withId(R.id.historyButton1))
+        val button2 = onView(withId(R.id.historyButton2))
+        val button3 = onView(withId(R.id.historyButton3))
+
+        onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
+        checkHistoryChecked(1)
+
+        button0.perform(click())
+        checkHistoryChecked(0)
+
+        button2.perform(click())
+        checkHistoryChecked(2)
+
+        button3.perform(click())
+        checkHistoryChecked(3)
+
+        button1.perform(click())
+        checkHistoryChecked(1)
     }
 
     @Test
     fun closeButton() {
+        openFragment()
         onView(withId(R.id.closeButton)).perform(forceClick())
         onView(withText("Calculator")).check(matches(isDisplayed()))
     }
 
     @Test
     fun deviceBackButton() {
+        openFragment()
         pressBack()
         onView(withText("Calculator")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun settingsButton() {
+        // enabled settings button
+        openFragment()
+        onView(withId(R.id.settingsButtonSwitch)).perform(click())
+        closeFragment()
+
+        // open settings
+        onView(withText("Calculator")).check(matches(isDisplayed()))
+        onView(withId(R.id.settingsButton)).perform(click())
+        onView(withText("Settings")).check(matches(isDisplayed()))
+
+        // settings button switch not displayed
+        onView(withId(R.id.settingsButtonSwitch)).check(isNotPresented())
+
+        // full ui otherwise displayed
+        checkInitialSettings()
+        onView(withId(R.id.resetSettingsButton)).check(matches(isDisplayed()))
+        onView(withId(R.id.randomizeSettingsButton)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun switchSettingsMaintained() = testSwitchSettingsMaintained()
+
+    @Test
+    fun resetButton() = testResetButton()
+
+    @Test
+    fun randomizeButton() = testRandomizeButton()
+
+    private fun testSwitch(@IdRes id: Int, initialChecked: Boolean) {
+        val switch = onView(withId(id))
+        val firstCheck = ternaryIf(initialChecked, isChecked(), isNotChecked())
+        val secondCheck = ternaryIf(initialChecked, isNotChecked(), isChecked())
+
+        switch.check(matches(allOf(isDisplayed(), firstCheck)))
+
+        switch.perform(click())
+        switch.check(matches(allOf(isDisplayed(), secondCheck)))
+
+        switch.perform(click())
+        switch.check(matches(allOf(isDisplayed(), firstCheck)))
+    }
+
+    private fun checkHistoryChecked(checked: Int) {
+        val buttons = listOf(
+            onView(withId(R.id.historyButton0)),
+            onView(withId(R.id.historyButton1)),
+            onView(withId(R.id.historyButton2)),
+            onView(withId(R.id.historyButton3)),
+        )
+
+        for (button in buttons.withIndex()) {
+            if (button.index == checked) {
+                button.value.check(matches(isChecked()))
+            } else {
+                button.value.check(matches(isNotChecked()))
+            }
+        }
     }
 }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
@@ -1,0 +1,78 @@
+package xyz.lbres.trickcalculator.ui.settings
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.allOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import xyz.lbres.trickcalculator.MainActivity
+import xyz.lbres.trickcalculator.R
+import xyz.lbres.trickcalculator.helpers.forceClick
+
+@RunWith(AndroidJUnit4::class)
+class SettingsFragmentTest {
+    @Rule
+    @JvmField
+    val rule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Before
+    fun setupTest() {
+        // open fragment
+        val infoButton = onView(withId(R.id.infoButton))
+        infoButton.check(matches(isDisplayed()))
+        infoButton.perform(click())
+        onView(withId(R.id.title)).perform(click())
+    }
+
+    @Test
+    fun loadActionBarWithTitle() {
+        val expectedTitle = "Settings"
+        onView(withId(R.id.title)).check(matches(withText(expectedTitle)))
+    }
+
+    @Test
+    fun loadFullUi() {
+        onView(withId(R.id.applyParensSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+        onView(withId(R.id.applyDecimalsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+        onView(withId(R.id.shuffleComputationSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+        onView(withId(R.id.shuffleNumbersSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+        onView(withId(R.id.shuffleOperatorsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+
+        onView(withId(R.id.clearOnErrorSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+        onView(withId(R.id.settingsButtonSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+
+        onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
+        onView(withId(R.id.historyButton1)).check(matches(isChecked()))
+
+        onView(withId(R.id.resetSettingsButton)).check(matches(isDisplayed()))
+        onView(withId(R.id.randomizeSettingsButton)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun interactWithUi() {
+        // TODO
+    }
+
+    @Test
+    fun closeButton() {
+        onView(withId(R.id.closeButton)).perform(forceClick())
+        onView(withText("Calculator")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun deviceBackButton() {
+        pressBack()
+        onView(withText("Calculator")).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
@@ -39,7 +39,6 @@ class SettingsFragmentTest {
     fun loadFullUi() {
         openFragment()
         checkInitialSettings()
-        onView(withId(R.id.settingsButtonSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
         onView(withId(R.id.resetSettingsButton)).check(matches(isDisplayed()))
         onView(withId(R.id.randomizeSettingsButton)).check(matches(isDisplayed()))
     }
@@ -104,7 +103,7 @@ class SettingsFragmentTest {
         onView(withId(R.id.settingsButtonSwitch)).check(isNotPresented())
 
         // full ui otherwise displayed
-        checkInitialSettings()
+        checkInitialSettings(checkSettingsButton = false)
         onView(withId(R.id.resetSettingsButton)).check(matches(isDisplayed()))
         onView(withId(R.id.randomizeSettingsButton)).check(matches(isDisplayed()))
     }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
@@ -58,24 +58,19 @@ class SettingsFragmentTest {
         testSwitch(R.id.settingsButtonSwitch, false)
 
         // history group
-        val button0 = onView(withId(R.id.historyButton0))
-        val button1 = onView(withId(R.id.historyButton1))
-        val button2 = onView(withId(R.id.historyButton2))
-        val button3 = onView(withId(R.id.historyButton3))
-
         onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
         checkHistoryChecked(1)
 
-        button0.perform(click())
+        onView(withId(R.id.historyButton0)).perform(click())
         checkHistoryChecked(0)
 
-        button2.perform(click())
+        onView(withId(R.id.historyButton2)).perform(click())
         checkHistoryChecked(2)
 
-        button3.perform(click())
+        onView(withId(R.id.historyButton3)).perform(click())
         checkHistoryChecked(3)
 
-        button1.perform(click())
+        onView(withId(R.id.historyButton1)).perform(click())
         checkHistoryChecked(1)
     }
 
@@ -131,16 +126,16 @@ class SettingsFragmentTest {
      */
     private fun testSwitch(@IdRes id: Int, initialChecked: Boolean) {
         val switch = onView(withId(id))
-        val firstCheck = ternaryIf(initialChecked, isChecked(), isNotChecked())
-        val secondCheck = ternaryIf(initialChecked, isNotChecked(), isChecked())
+        val inititalCheck = ternaryIf(initialChecked, isChecked(), isNotChecked())
+        val oppositeCheck = ternaryIf(initialChecked, isNotChecked(), isChecked())
 
-        switch.check(matches(allOf(isDisplayed(), firstCheck)))
-
-        switch.perform(click())
-        switch.check(matches(allOf(isDisplayed(), secondCheck)))
+        switch.check(matches(allOf(isDisplayed(), inititalCheck)))
 
         switch.perform(click())
-        switch.check(matches(allOf(isDisplayed(), firstCheck)))
+        switch.check(matches(allOf(isDisplayed(), oppositeCheck)))
+
+        switch.perform(click())
+        switch.check(matches(allOf(isDisplayed(), inititalCheck)))
     }
 
     /**

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsFragmentTest.kt
@@ -123,6 +123,12 @@ class SettingsFragmentTest {
     @Test
     fun randomizeButton() = testRandomizeButton()
 
+    /**
+     * Run basic tests on a switch by checking and unchecking
+     *
+     * @param id [IdRes]: view ID of the switch
+     * @param initialChecked [Boolean]: if the switch is expected to be checked initially, before any interaction
+     */
     private fun testSwitch(@IdRes id: Int, initialChecked: Boolean) {
         val switch = onView(withId(id))
         val firstCheck = ternaryIf(initialChecked, isChecked(), isNotChecked())
@@ -137,6 +143,12 @@ class SettingsFragmentTest {
         switch.check(matches(allOf(isDisplayed(), firstCheck)))
     }
 
+    /**
+     * Check the history radio group to ensure that the correct button is checked, and all others are unchecked.
+     * Checks all buttons because some radio groups may allow multiple buttons to be checked.
+     *
+     * @param checked [Int]: index of button expected to be checked
+     */
     private fun checkHistoryChecked(checked: Int) {
         val buttons = listOf(
             onView(withId(R.id.historyButton0)),

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
@@ -13,6 +13,8 @@ import xyz.lbres.trickcalculator.R
 class SettingsModifiedViewAssertion : ViewAssertion {
     /**
      * Assert that a the settings do not match the initial settings
+     *
+     * @param view [View]?: view to check, expected to be root of a settings fragment
      */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (view == null) {

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
@@ -7,7 +7,13 @@ import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 import xyz.lbres.trickcalculator.R
 
-class SettingsRandomizedViewAssertion : ViewAssertion {
+/**
+ * [ViewAssertion] to assert that settings displayed in settings fragment do not match initial settings
+ */
+class SettingsModifiedViewAssertion : ViewAssertion {
+    /**
+     * Assert that a the settings do not match the initial settings
+     */
     override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
         if (view == null) {
             throw AssertionError("Settings view is null")

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsModifiedViewAssertion.kt
@@ -28,7 +28,7 @@ class SettingsModifiedViewAssertion : ViewAssertion {
                 R.id.historyButton1 -> 1
                 R.id.historyButton2 -> 2
                 R.id.historyButton3 -> 3
-                else -> -1
+                else -> initialSettings.historyRandomness
             }
 
             val viewSettings = Settings(

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsRandomizedViewAssertion.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/SettingsRandomizedViewAssertion.kt
@@ -1,0 +1,42 @@
+package xyz.lbres.trickcalculator.ui.settings
+
+import android.view.View
+import android.widget.RadioGroup
+import androidx.appcompat.widget.SwitchCompat
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.ViewAssertion
+import xyz.lbres.trickcalculator.R
+
+class SettingsRandomizedViewAssertion : ViewAssertion {
+    override fun check(view: View?, noViewFoundException: NoMatchingViewException?) {
+        if (view == null) {
+            throw AssertionError("Settings view is null")
+        } else {
+            val initialSettings = Settings()
+
+            val historyGroup = view.findViewById<RadioGroup>(R.id.historyRandomnessGroup)
+            val historyRandomness = when (historyGroup.checkedRadioButtonId) {
+                R.id.historyButton0 -> 0
+                R.id.historyButton1 -> 1
+                R.id.historyButton2 -> 2
+                R.id.historyButton3 -> 3
+                else -> -1
+            }
+
+            val viewSettings = Settings(
+                view.findViewById<SwitchCompat>(R.id.applyDecimalsSwitch).isChecked,
+                view.findViewById<SwitchCompat>(R.id.applyParensSwitch).isChecked,
+                view.findViewById<SwitchCompat>(R.id.clearOnErrorSwitch).isChecked,
+                historyRandomness,
+                view.findViewById<SwitchCompat>(R.id.settingsButtonSwitch).isChecked,
+                view.findViewById<SwitchCompat>(R.id.shuffleComputationSwitch).isChecked,
+                view.findViewById<SwitchCompat>(R.id.shuffleNumbersSwitch).isChecked,
+                view.findViewById<SwitchCompat>(R.id.shuffleOperatorsSwitch).isChecked,
+            )
+
+            if (viewSettings == initialSettings) {
+                throw AssertionError("Randomized settings match initial settings")
+            }
+        }
+    }
+}

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
@@ -35,9 +35,12 @@ fun settingsRandomized() = SettingsModifiedViewAssertion()
 
 /**
  * Check that settings match initial settings.
- * Checks all settings except setting to show/hide the settings button on the main screen.
+ * Optionally checks switch to show/hide settings button.
+ *
+ * @param checkSettingsButton [Boolean]: if the setting for showing settings button should be checked.
+ * Defaults to true.
  */
-fun checkInitialSettings() {
+fun checkInitialSettings(checkSettingsButton: Boolean = true) {
     onView(withId(R.id.applyParensSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
     onView(withId(R.id.applyDecimalsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
     onView(withId(R.id.shuffleComputationSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
@@ -48,4 +51,8 @@ fun checkInitialSettings() {
 
     onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
     onView(withId(R.id.historyButton1)).check(matches(isChecked()))
+
+    if (checkSettingsButton) {
+        onView(withId(R.id.settingsButtonSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+    }
 }

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
@@ -29,7 +29,7 @@ fun closeFragment() {
 }
 
 /**
- * Wrapper function for create a [SettingsModifiedViewAssertion]
+ * Wrapper function to create a [SettingsModifiedViewAssertion]
  */
 fun settingsRandomized() = SettingsModifiedViewAssertion()
 

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
@@ -1,0 +1,36 @@
+package xyz.lbres.trickcalculator.ui.settings
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import org.hamcrest.Matchers.allOf
+import xyz.lbres.trickcalculator.R
+import xyz.lbres.trickcalculator.helpers.forceClick
+
+fun openFragment() {
+    val infoButton = onView(withId(R.id.infoButton))
+    infoButton.check(matches(isDisplayed()))
+    infoButton.perform(click())
+    onView(withId(R.id.title)).perform(click())
+}
+
+fun closeFragment() {
+    onView(withId(R.id.closeButton)).perform(forceClick())
+}
+
+fun settingsRandomized() = SettingsRandomizedViewAssertion()
+
+// check all initial settings other than settings button
+fun checkInitialSettings() {
+    onView(withId(R.id.applyParensSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+    onView(withId(R.id.applyDecimalsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+    onView(withId(R.id.shuffleComputationSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+    onView(withId(R.id.shuffleNumbersSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+    onView(withId(R.id.shuffleOperatorsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
+
+    onView(withId(R.id.clearOnErrorSwitch)).check(matches(allOf(isDisplayed(), isNotChecked())))
+
+    onView(withId(R.id.historyRandomnessGroup)).check(matches(isDisplayed()))
+    onView(withId(R.id.historyButton1)).check(matches(isChecked()))
+}

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/settingsHelpers.kt
@@ -3,11 +3,17 @@ package xyz.lbres.trickcalculator.ui.settings
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.hamcrest.Matchers.allOf
 import xyz.lbres.trickcalculator.R
 import xyz.lbres.trickcalculator.helpers.forceClick
 
+/**
+ * Open settings fragment through attributions fragment
+ */
 fun openFragment() {
     val infoButton = onView(withId(R.id.infoButton))
     infoButton.check(matches(isDisplayed()))
@@ -15,13 +21,22 @@ fun openFragment() {
     onView(withId(R.id.title)).perform(click())
 }
 
+/**
+ * Click close button
+ */
 fun closeFragment() {
     onView(withId(R.id.closeButton)).perform(forceClick())
 }
 
-fun settingsRandomized() = SettingsRandomizedViewAssertion()
+/**
+ * Wrapper function for create a [SettingsModifiedViewAssertion]
+ */
+fun settingsRandomized() = SettingsModifiedViewAssertion()
 
-// check all initial settings other than settings button
+/**
+ * Check that settings match initial settings.
+ * Checks all settings except setting to show/hide the settings button on the main screen.
+ */
 fun checkInitialSettings() {
     onView(withId(R.id.applyParensSwitch)).check(matches(allOf(isDisplayed(), isChecked())))
     onView(withId(R.id.applyDecimalsSwitch)).check(matches(allOf(isDisplayed(), isChecked())))

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
@@ -1,0 +1,188 @@
+package xyz.lbres.trickcalculator.ui.settings
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.*
+import org.hamcrest.CoreMatchers.allOf
+import xyz.lbres.trickcalculator.R
+import xyz.lbres.trickcalculator.helpers.isNotPresented
+
+private val applyParensSwitch = onView(withId(R.id.applyParensSwitch))
+private val applyDecimalsSwitch = onView(withId(R.id.applyDecimalsSwitch))
+private val clearOnErrorSwitch = onView(withId(R.id.clearOnErrorSwitch))
+private val settingsButtonSwitch = onView(withId(R.id.settingsButtonSwitch))
+private val shuffleComputationSwitch = onView(withId(R.id.shuffleComputationSwitch))
+private val shuffleNumbersSwitch = onView(withId(R.id.shuffleNumbersSwitch))
+private val shuffleOperatorsSwitch = onView(withId(R.id.shuffleOperatorsSwitch))
+
+private val settingsButton = onView(withId(R.id.settingsButton))
+
+fun testSwitchSettingsMaintained() {
+    // set ui
+    openFragment()
+
+    applyParensSwitch.perform(click())
+    applyDecimalsSwitch.perform(click())
+    clearOnErrorSwitch.perform(click())
+    shuffleComputationSwitch.perform(click())
+    shuffleNumbersSwitch.perform(click())
+    shuffleOperatorsSwitch.perform(click())
+    onView(withId(R.id.historyButton3)).perform(click())
+
+    settingsButtonSwitch.perform(click())
+
+    applyParensSwitch.check(matches(isNotChecked()))
+    applyDecimalsSwitch.check(matches(isNotChecked()))
+    clearOnErrorSwitch.check(matches(isChecked()))
+    shuffleComputationSwitch.check(matches(isChecked()))
+    shuffleNumbersSwitch.check(matches(isChecked()))
+    shuffleOperatorsSwitch.check(matches(isNotChecked()))
+    onView(withId(R.id.historyButton3)).check(matches(isChecked()))
+
+    settingsButtonSwitch.check(matches(isChecked()))
+
+    closeFragment()
+
+    // check values after re-opening
+    openFragment()
+
+    applyParensSwitch.check(matches(isNotChecked()))
+    applyDecimalsSwitch.check(matches(isNotChecked()))
+    clearOnErrorSwitch.check(matches(isChecked()))
+    shuffleComputationSwitch.check(matches(isChecked()))
+    shuffleNumbersSwitch.check(matches(isChecked()))
+    shuffleOperatorsSwitch.check(matches(isNotChecked()))
+    onView(withId(R.id.historyButton3)).check(matches(isChecked()))
+
+    settingsButtonSwitch.check(matches(allOf(isDisplayed(), isChecked())))
+
+    shuffleOperatorsSwitch.perform(click())
+    onView(withId(R.id.historyButton2)).perform(click())
+    shuffleOperatorsSwitch.check(matches(isChecked()))
+    onView(withId(R.id.historyButton2)).check(matches(isChecked()))
+
+    pressBack()
+
+    // check values after opening with settings button
+    settingsButton.perform(click())
+
+    applyParensSwitch.check(matches(isNotChecked()))
+    applyDecimalsSwitch.check(matches(isNotChecked()))
+    clearOnErrorSwitch.check(matches(isChecked()))
+    shuffleComputationSwitch.check(matches(isChecked()))
+    shuffleNumbersSwitch.check(matches(isChecked()))
+    shuffleOperatorsSwitch.check(matches(isChecked()))
+    onView(withId(R.id.historyButton2)).check(matches(isChecked()))
+
+    settingsButtonSwitch.check(isNotPresented())
+
+    applyParensSwitch.perform(click())
+    applyParensSwitch.check(matches(isChecked()))
+
+    closeFragment()
+
+    // re-open to check settings from settings fragment
+    openFragment()
+    applyParensSwitch.check(matches(isChecked()))
+    applyDecimalsSwitch.check(matches(isNotChecked()))
+    clearOnErrorSwitch.check(matches(isChecked()))
+    shuffleComputationSwitch.check(matches(isChecked()))
+    shuffleNumbersSwitch.check(matches(isChecked()))
+    shuffleOperatorsSwitch.check(matches(isChecked()))
+    onView(withId(R.id.historyButton2)).check(matches(isChecked()))
+
+    settingsButtonSwitch.check(matches(allOf(isDisplayed(), isChecked())))
+    settingsButtonSwitch.perform(click())
+    settingsButtonSwitch.check(matches(allOf(isDisplayed(), isNotChecked())))
+
+    closeFragment()
+
+    // settings button is not present
+    settingsButton.check(isNotPresented())
+}
+
+fun testResetButton() {
+    val resetButton = onView(withId(R.id.resetSettingsButton))
+
+    // modify settings
+    openFragment()
+    applyParensSwitch.perform(click())
+    shuffleComputationSwitch.perform(click())
+    shuffleNumbersSwitch.perform(click())
+    shuffleOperatorsSwitch.perform(click())
+    onView(withId(R.id.historyButton3)).perform(click())
+
+    // reset
+    resetButton.perform(click())
+    onView(withText("Calculator")).check(matches(isDisplayed()))
+    settingsButton.check(isNotPresented())
+
+    // check reset settings
+    openFragment()
+    checkInitialSettings()
+
+    // modify settings + enabled settings button
+    shuffleNumbersSwitch.perform(click())
+    shuffleOperatorsSwitch.perform(click())
+    onView(withId(R.id.historyButton2)).perform(click())
+
+    settingsButtonSwitch.perform(click())
+
+    closeFragment()
+
+    // open settings button w/ existing changes + reset
+    settingsButton.check(matches(isDisplayed())).perform(click())
+    resetButton.perform(click())
+    onView(withText("Calculator")).check(matches(isDisplayed()))
+
+    // validate that settings button still exists
+    settingsButton.check(matches(isDisplayed())).perform(click())
+    checkInitialSettings()
+
+    // modify settings through settings button + reset
+    applyDecimalsSwitch.perform(click())
+    clearOnErrorSwitch.perform(click())
+    resetButton.perform(click())
+
+    // validate that settings button is still checked
+    openFragment()
+    checkInitialSettings()
+    settingsButtonSwitch.check(matches(isChecked()))
+
+    // reset through regular method + validate settings still exists
+    resetButton.perform(click())
+    settingsButton.check(matches(isDisplayed()))
+}
+
+fun testRandomizeButton() {
+    val randomizeButton = onView(withId(R.id.randomizeSettingsButton))
+
+    // settings button disappears
+    openFragment()
+    settingsButtonSwitch.perform(click())
+    closeFragment()
+    settingsButton.check(matches(isDisplayed()))
+    openFragment()
+    randomizeButton.perform(click())
+    settingsButton.check(isNotPresented())
+    openFragment()
+    settingsButtonSwitch.perform(click())
+    closeFragment()
+    settingsButton.perform(click())
+    randomizeButton.perform(click())
+    settingsButton.check(isNotPresented())
+
+    openFragment()
+
+    try {
+        onView(isRoot()).check(settingsRandomized())
+    } catch (e: AssertionError) {
+        // one retry, in case of rare event where randomized = initial settings
+        randomizeButton.perform(click())
+        openFragment()
+        onView(isRoot()).check(settingsRandomized())
+    }
+}

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
@@ -144,7 +144,7 @@ fun testResetButton() {
 
     // validate that settings button still exists
     settingsButton.check(matches(isDisplayed())).perform(click())
-    checkInitialSettings()
+    checkInitialSettings(checkSettingsButton = false)
 
     // modify settings through settings button + reset
     applyDecimalsSwitch.perform(click())
@@ -153,7 +153,7 @@ fun testResetButton() {
 
     // validate that settings button is still checked
     openFragment()
-    checkInitialSettings()
+    checkInitialSettings(checkSettingsButton = false)
     settingsButtonSwitch.check(matches(isChecked()))
 
     // reset through regular method + validate settings still exists

--- a/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
+++ b/app/src/espresso/java/xyz/lbres/trickcalculator/ui/settings/testSettingsChanged.kt
@@ -4,8 +4,12 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
 import xyz.lbres.trickcalculator.R
 import xyz.lbres.trickcalculator.helpers.isNotPresented

--- a/app/src/main/java/xyz/lbres/trickcalculator/ui/settings/Settings.kt
+++ b/app/src/main/java/xyz/lbres/trickcalculator/ui/settings/Settings.kt
@@ -20,4 +20,19 @@ data class Settings(
         shuffleNumbers = false,
         shuffleOperators = true
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is Settings) {
+            return false
+        }
+
+        return applyDecimals == other.applyDecimals
+                && applyParens == other.applyParens
+                && clearOnError == other.clearOnError
+                && historyRandomness == other.historyRandomness
+                && showSettingsButton == other.showSettingsButton
+                && shuffleComputation == other.shuffleComputation
+                && shuffleNumbers == other.shuffleNumbers
+                && shuffleOperators == other.shuffleOperators
+    }
 }

--- a/app/src/main/java/xyz/lbres/trickcalculator/ui/settings/Settings.kt
+++ b/app/src/main/java/xyz/lbres/trickcalculator/ui/settings/Settings.kt
@@ -26,13 +26,13 @@ data class Settings(
             return false
         }
 
-        return applyDecimals == other.applyDecimals
-                && applyParens == other.applyParens
-                && clearOnError == other.clearOnError
-                && historyRandomness == other.historyRandomness
-                && showSettingsButton == other.showSettingsButton
-                && shuffleComputation == other.shuffleComputation
-                && shuffleNumbers == other.shuffleNumbers
-                && shuffleOperators == other.shuffleOperators
+        return applyDecimals == other.applyDecimals &&
+            applyParens == other.applyParens &&
+            clearOnError == other.clearOnError &&
+            historyRandomness == other.historyRandomness &&
+            showSettingsButton == other.showSettingsButton &&
+            shuffleComputation == other.shuffleComputation &&
+            shuffleNumbers == other.shuffleNumbers &&
+            shuffleOperators == other.shuffleOperators
     }
 }


### PR DESCRIPTION
## Details
* Add espresso tests for settings fragment, including new ViewAssertion specific to settings
* Fix issues in NotPresentedViewAssertion

## Checklists
### Testing
* [x] New and existing unit tests pass
* [ ] Unit tests have been written for all new computation
    * I __don't care__ how much work it is. Write the tests. Your future self will thank you. In this repo, we ♥ tests.
* [x] New and existing espresso tests pass
* [ ] Espresso tests have been written for all UI changes

### Images
* [ ] Any new/deleted images have been updated in
    * [ ] the image attributions fragment
    * [ ] the README

### Documentation
* [ ] Any new or changed settings have been updated as described in the settings README
  * This includes documentation in the main README
* [ ] Any new uses of settings have been documented in the settings README
* [x] If function signatures changed, the docstrings have been updated

### Other
* [x] ktlint has run successfully

## Comments
Fun but optional
